### PR TITLE
fix: don't police security repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "cross-env AUTO_TUNNEL_NGROK=e-sheriff yarn start",
+    "lint": "prettier --check \"src/**/*.{ts,tsx}\"",
     "prettier:write": "prettier --write \"src/**/*.{ts,tsx}\"",
     "start": "node lib/index.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ webhooks.on(
   }),
 );
 
-const importantBranchMatcher = () => process.env.SHERIFF_IMPORTANT_BRANCH ? new RegExp('(^[0-9]+-[0-9]+-x$)|(^[0-9]+-x-y$)') : null;
+const importantBranchMatcher = () =>
+  process.env.SHERIFF_IMPORTANT_BRANCH ? new RegExp('(^[0-9]+-[0-9]+-x$)|(^[0-9]+-x-y$)') : null;
 
 webhooks.on(
   'delete',
@@ -147,76 +148,111 @@ webhooks.on(
   }),
 );
 
-webhooks.on('organization.member_invited', hook(async event => {
-  await MessageBuilder.create()
-    .addBlock(createMessageBlock(`A new member was just invited to the "${event.payload.organization.login}" organization`))
-    .addUser(event.payload.membership.user, 'Invited Member')
-    .addBlame(event.payload.sender)
-    .addSeverity('normal')
-    .send()
-}));
+webhooks.on(
+  'organization.member_invited',
+  hook(async event => {
+    await MessageBuilder.create()
+      .addBlock(
+        createMessageBlock(
+          `A new member was just invited to the "${event.payload.organization.login}" organization`,
+        ),
+      )
+      .addUser(event.payload.membership.user, 'Invited Member')
+      .addBlame(event.payload.sender)
+      .addSeverity('normal')
+      .send();
+  }),
+);
 
-webhooks.on('organization.member_added', hook(async event => {
-  await MessageBuilder.create()
-    .addBlock(createMessageBlock(`A new member was just added to the "${event.payload.organization.login}" organization`))
-    .addUser(event.payload.membership.user, 'New Member')
-    .addBlame(event.payload.sender)
-    .addSeverity('normal')
-    .send()
-}));
+webhooks.on(
+  'organization.member_added',
+  hook(async event => {
+    await MessageBuilder.create()
+      .addBlock(
+        createMessageBlock(
+          `A new member was just added to the "${event.payload.organization.login}" organization`,
+        ),
+      )
+      .addUser(event.payload.membership.user, 'New Member')
+      .addBlame(event.payload.sender)
+      .addSeverity('normal')
+      .send();
+  }),
+);
 
-webhooks.on('organization.member_removed', hook(async event => {
-  await MessageBuilder.create()
-    .addBlock(createMessageBlock(`A member was just removed from the "${event.payload.organization.login}" organization`))
-    .addUser(event.payload.membership.user, 'Removed Member')
-    .addBlame(event.payload.sender)
-    .addSeverity('normal')
-    .send()
-}));
+webhooks.on(
+  'organization.member_removed',
+  hook(async event => {
+    await MessageBuilder.create()
+      .addBlock(
+        createMessageBlock(
+          `A member was just removed from the "${event.payload.organization.login}" organization`,
+        ),
+      )
+      .addUser(event.payload.membership.user, 'Removed Member')
+      .addBlame(event.payload.sender)
+      .addSeverity('normal')
+      .send();
+  }),
+);
 
-webhooks.on('organization.renamed', hook(async event => {
-  await MessageBuilder.create()
-    .addBlock(
-      createMessageBlock(`The organization was just renamed to \`${event.payload.organization.login}\`, this is incredibly unexpected`)
-    )
-    .addBlame(event.payload.sender)
-    .addSeverity('critical')
-    .send()
-}))
+webhooks.on(
+  'organization.renamed',
+  hook(async event => {
+    await MessageBuilder.create()
+      .addBlock(
+        createMessageBlock(
+          `The organization was just renamed to \`${event.payload.organization.login}\`, this is incredibly unexpected`,
+        ),
+      )
+      .addBlame(event.payload.sender)
+      .addSeverity('critical')
+      .send();
+  }),
+);
 
-webhooks.on('public', hook(async event => {
-  await MessageBuilder.create()
-    .addBlock(
-      createMessageBlock(`A private repository was just made public`)
-    )
-    .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
-    .addSeverity('warning')
-    .send()
-}));
+webhooks.on(
+  'public',
+  hook(async event => {
+    await MessageBuilder.create()
+      .addBlock(createMessageBlock(`A private repository was just made public`))
+      .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
+      .addSeverity('warning')
+      .send();
+  }),
+);
 
-webhooks.on('release', hook(async event => {
-  const message = MessageBuilder.create();
-  let severity: 'critical' | 'warning' | 'normal' = 'normal';
-  message.addBlock(createMessageBlock(`The "${event.payload.release.name}" release was just ${event.payload.action}`))
-  switch (event.payload.action) {
-    case 'deleted':  
-      severity = 'critical'
-      break;
-    case 'unpublished':
-    case 'edited':
-      severity = 'warning'
-      break;
-    case 'created':
-    case 'published':
-    case 'prereleased':
-      break;
-    default:
-      return;
-  }
-  await message.addRepositoryAndBlame(event.payload.repository, event.payload.sender)
-    .addSeverity(severity)
-    .send()
-}));
+webhooks.on(
+  'release',
+  hook(async event => {
+    const message = MessageBuilder.create();
+    let severity: 'critical' | 'warning' | 'normal' = 'normal';
+    message.addBlock(
+      createMessageBlock(
+        `The "${event.payload.release.name}" release was just ${event.payload.action}`,
+      ),
+    );
+    switch (event.payload.action) {
+      case 'deleted':
+        severity = 'critical';
+        break;
+      case 'unpublished':
+      case 'edited':
+        severity = 'warning';
+        break;
+      case 'created':
+      case 'published':
+      case 'prereleased':
+        break;
+      default:
+        return;
+    }
+    await message
+      .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
+      .addSeverity(severity)
+      .send();
+  }),
+);
 
 const app = express();
 

--- a/src/permissions/plugins/gsuite/index.ts
+++ b/src/permissions/plugins/gsuite/index.ts
@@ -90,12 +90,14 @@ class GSuitePlugin implements Plugin {
         'as it did not exist',
       );
       if (!IS_DRY_RUN) {
-        existingGroup = (await service.groups.insert({
-          requestBody: {
-            email: expectedEmail,
-            name: team.displayName,
-          },
-        })).data!;
+        existingGroup = (
+          await service.groups.insert({
+            requestBody: {
+              email: expectedEmail,
+              name: team.displayName,
+            },
+          })
+        ).data!;
       }
     }
 
@@ -121,7 +123,10 @@ class GSuitePlugin implements Plugin {
         )
       ) {
         // Ignore slack notification emails, we need those
-        if (!process.env.SHERIFF_SLACK_DOMAIN || !member.email!.endsWith(`@${process.env.SHERIFF_SLACK_DOMAIN}.slack.com`)) {
+        if (
+          !process.env.SHERIFF_SLACK_DOMAIN ||
+          !member.email!.endsWith(`@${process.env.SHERIFF_SLACK_DOMAIN}.slack.com`)
+        ) {
           builder.addContext(
             `:skull_and_crossbones: Evicting \`${member.email}\` out of GSuite group \`${expectedEmail}\``,
           );

--- a/src/permissions/plugins/index.ts
+++ b/src/permissions/plugins/index.ts
@@ -3,7 +3,7 @@ import { Plugin } from './Plugin';
 import { gsuitePlugin } from './gsuite';
 import { slackPlugin } from './slack';
 
-const enabledPlugins = (process.env.SHERIFF_PLUGINS || '').split(',')
+const enabledPlugins = (process.env.SHERIFF_PLUGINS || '').split(',');
 
 export const plugins: Plugin[] = [];
 


### PR DESCRIPTION
Security advisory repos can be fetched when all repos in an organization are fetched, but 404 when one tries to fetch them individually. Sheriff was erring as a result of this.

This fixes the issues by filtering out from the org repos list anything matching the name format of a GH sec advisory repo.

cc @MarshallOfSound 