### PR TITLE
refactor: use authNarrowing from auth-github-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   },
   "author": "Samuel Attard",
   "dependencies": {
-    "@electron/github-app-auth": "^1.2.0",
-    "@octokit/auth-app": "^3.6.1",
+    "@electron/github-app-auth": "^1.4.0",
     "@octokit/graphql": "^4.8.0",
     "@octokit/rest": "^18.12.0",
     "@octokit/webhooks": "^9.23.0",

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -2,12 +2,38 @@ import { graphql } from '@octokit/graphql';
 import { Octokit } from '@octokit/rest';
 import {
   appCredentialsFromString,
+  AuthNarrowing,
   getAuthOptionsForRepo,
   getTokenForRepo,
 } from '@electron/github-app-auth';
 import { SHERIFF_GITHUB_APP_CREDS, ORGANIZATION_NAME, REPO_NAME } from './constants';
+import { IS_DRY_RUN } from './helpers';
 
 require('dotenv-safe').config();
+
+function getAuthNarrowing(): AuthNarrowing {
+  // In a dry run, ensure we only have read access to resources to avoid
+  // any mishaps
+  if (IS_DRY_RUN) {
+    return {
+      permissions: {
+        administration: 'read',
+        members: 'read',
+        contents: 'read',
+        metadata: 'read',
+      },
+    };
+  }
+  // Otherwise we should get a token with write access to admin/members
+  return {
+    permissions: {
+      administration: 'write',
+      members: 'write',
+      contents: 'read',
+      metadata: 'read',
+    },
+  };
+}
 
 let octokit: Octokit;
 export async function getOctokit() {
@@ -20,6 +46,7 @@ export async function getOctokit() {
       name: REPO_NAME,
     },
     creds,
+    getAuthNarrowing(),
   );
   octokit = new Octokit({ ...authOpts });
   return octokit;
@@ -33,6 +60,7 @@ export async function graphyOctokit() {
       name: REPO_NAME,
     },
     creds,
+    getAuthNarrowing(),
   );
   return graphql.defaults({
     headers: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@electron/github-app-auth@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@electron/github-app-auth/-/github-app-auth-1.2.0.tgz"
-  integrity sha512-nyFANfFof4wK03QSgwbj36j8xVeFPKFJCmjv8D1xEmjohu9JULHQlsePX7ZDM4RRxBRpjP2FCjy/mY3/iwx6dA==
+"@electron/github-app-auth@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@electron/github-app-auth/-/github-app-auth-1.4.0.tgz#74a6247299237093d5558e0012b6ea0af4265744"
+  integrity sha512-fzGQmBohQIAreqorA0v1NcMlsaNxcLCZAGlFbwm9AR78xQi0ZHlTRAYYOaWh//Hfja3WIF/LI5i8c/SJ5JYyEQ==
   dependencies:
     "@octokit/auth-app" "^3.6.1"
     "@octokit/rest" "^18.12.0"


### PR DESCRIPTION
This ensures that during a dry run we don't have a token with write access to anything in order to avoid any potential mishaps.