### PR TITLE
fix: slack variable accepts true/false, don't gsuite auth if creds missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 image-run:
 	docker run --rm -p 8080:8080 --env-file .env $$(whoami)/sheriff
 
+image-run-job:
+	docker run --rm --env-file .env $$(whoami)/sheriff node lib/permissions/run.js
+
 image:
 	docker build -t $$(whoami)/sheriff .
 

--- a/src/permissions/plugins/gsuite/auth.ts
+++ b/src/permissions/plugins/gsuite/auth.ts
@@ -8,7 +8,11 @@ const SCOPES = [
   'https://www.googleapis.com/auth/apps.groups.settings',
 ];
 
-const credentials = JSON.parse(Buffer.from(GSUITE_CREDENTIALS!, 'base64').toString());
+let credentials: any = {};
+
+if (GSUITE_CREDENTIALS != undefined && GSUITE_CREDENTIALS != '') {
+  credentials = JSON.parse(Buffer.from(GSUITE_CREDENTIALS!, 'base64').toString());
+}
 
 export function getAuthorizedClient() {
   const { client_secret, client_id, redirect_uris } = credentials.installed;

--- a/src/permissions/run.ts
+++ b/src/permissions/run.ts
@@ -150,7 +150,7 @@ const validateConfigFast = async (config: PermissionsConfig) => {
         gsuite: Joi.object({
           privacy: Joi.string().only('internal', 'external').required(),
         }).optional(),
-        slack: Joi.string().min(1).allow(true).optional(),
+        slack: Joi.string().min(1).allow(true).allow(false).optional(),
       })
       .required(),
     repositories: Joi.array()


### PR DESCRIPTION
And add `make image-run-job` for local container running :) 

cc @MarshallOfSound 