### PR TITLE
feat: auto-revert permission changes based on config

### DIFF
--- a/src/MessageBuilder.ts
+++ b/src/MessageBuilder.ts
@@ -162,6 +162,19 @@ export class MessageBuilder {
     return this;
   }
 
+  public addReverted() {
+    this.addBlock({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: ':black_left_pointing_double_triangle_with_vertical_bar:   *This permissions change was automatically reverted*',
+        },
+      ],
+    });
+    return this;
+  }
+
   public divide() {
     this.addBlock({
       type: 'divider',

--- a/src/MessageBuilder.ts
+++ b/src/MessageBuilder.ts
@@ -30,6 +30,12 @@ export const createMarkdownBlock = (msg: string): KnownBlock => ({
   },
 });
 
+export enum PermissionEnforcementAction {
+  ALLOW_CHANGE,
+  REVERT_CHANGE,
+  ADJUSTED_CHANGE,
+}
+
 export class MessageBuilder {
   private state: IncomingWebhookSendArguments = {};
   private eventPayload: unknown = null;
@@ -162,16 +168,30 @@ export class MessageBuilder {
     return this;
   }
 
-  public addReverted() {
-    this.addBlock({
-      type: 'context',
-      elements: [
-        {
-          type: 'mrkdwn',
-          text: ':black_left_pointing_double_triangle_with_vertical_bar:   *This permissions change was automatically reverted*',
-        },
-      ],
-    });
+  public addPermissionEnforcement(action: PermissionEnforcementAction) {
+    if (action == PermissionEnforcementAction.ALLOW_CHANGE) return this;
+
+    if (action === PermissionEnforcementAction.REVERT_CHANGE) {
+      this.addBlock({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: ':black_left_pointing_double_triangle_with_vertical_bar:   *This permissions change was automatically reverted*',
+          },
+        ],
+      });
+    } else {
+      this.addBlock({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: ':twisted_rightwards_arrows:   *This permissions change was automatically adjusted to the correct state*',
+          },
+        ],
+      });
+    }
     return this;
   }
 

--- a/src/MessageBuilder.ts
+++ b/src/MessageBuilder.ts
@@ -2,6 +2,7 @@ import { IncomingWebhook, IncomingWebhookSendArguments } from '@slack/webhook';
 import { RepositoryCreatedEvent } from '@octokit/webhooks-types';
 import { KnownBlock } from '@slack/types';
 import { AUTO_TUNNEL_NGROK, SHERIFF_HOST_URL, SLACK_WEBHOOK_URL } from './constants';
+import { SheriffAccessLevel } from './permissions/types';
 
 const HOST = AUTO_TUNNEL_NGROK ? `https://${AUTO_TUNNEL_NGROK}.ngrok.io` : SHERIFF_HOST_URL;
 
@@ -168,7 +169,10 @@ export class MessageBuilder {
     return this;
   }
 
-  public addPermissionEnforcement(action: PermissionEnforcementAction) {
+  public addPermissionEnforcement(
+    action: PermissionEnforcementAction,
+    expectedLevel?: SheriffAccessLevel,
+  ) {
     if (action == PermissionEnforcementAction.ALLOW_CHANGE) return this;
 
     if (action === PermissionEnforcementAction.REVERT_CHANGE) {
@@ -187,7 +191,7 @@ export class MessageBuilder {
         elements: [
           {
             type: 'mrkdwn',
-            text: ':twisted_rightwards_arrows:   *This permissions change was automatically adjusted to the correct state*',
+            text: `:twisted_rightwards_arrows:   *This permissions change was automatically adjusted to the correct state of \`${expectedLevel}\`*`,
           },
         ],
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,15 +137,19 @@ async function takeActionOnRepositoryCollaborator(
     repo: repo.name,
     affiliation: 'direct',
   });
-  const currentCollaborator = allCollaborators.find((c) => c.id === member.id)!;
+  const currentCollaborator = allCollaborators.find((c) => c.id === member.id);
 
-  const currentSheriffLevel = gitHubPermissionsToSheriffLevel(currentCollaborator.permissions!);
+  // currentCollaborator is undefined when this user was removed as a collaborator
+  // during this event
+  const currentSheriffLevel = currentCollaborator
+    ? gitHubPermissionsToSheriffLevel(currentCollaborator.permissions!)
+    : null;
   // The change resulted in an unexpected new state
-  if (currentSheriffLevel !== expectedLevel) {
+  if (!currentSheriffLevel || currentSheriffLevel !== expectedLevel) {
     await octokit.repos.addCollaborator({
       owner: repo.owner.login,
       repo: repo.name,
-      username: currentCollaborator.login,
+      username: member.login,
       permission: sheriffLevelToGitHubLevel(expectedLevel),
     });
     return PermissionEnforcementAction.REVERT_CHANGE;

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,7 +212,7 @@ webhooks.on(
     await MessageBuilder.create()
       .setEventPayload(event)
       .setNotificationContent(text)
-      .addBlock(createMessageBlock(text))
+      .addBlock(createMarkdownBlock(text))
       .addUser(event.payload.member, 'Collaborator')
       .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
       .addSeverity('normal')

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,7 @@ webhooks.on(
       .addBlock(createMessageBlock(text))
       .addUser(event.payload.member, 'Collaborator')
       .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
-      .addSeverity('critical')
+      .addSeverity('normal')
       .addReverted()
       .send();
   }),
@@ -186,7 +186,7 @@ webhooks.on(
       .addBlock(createMessageBlock(text))
       .addUser(event.payload.member, 'Collaborator')
       .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
-      .addSeverity('critical')
+      .addSeverity('normal')
       .addReverted()
       .send();
   }),
@@ -215,7 +215,7 @@ webhooks.on(
       .addBlock(createMessageBlock(text))
       .addUser(event.payload.member, 'Collaborator')
       .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
-      .addSeverity('critical')
+      .addSeverity('normal')
       .addReverted()
       .send();
   }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ webhooks.on(
       .addBlock(createMessageBlock(text))
       .addUser(event.payload.member, 'Collaborator')
       .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
-      .addSeverity('normal')
+      .addSeverity('critical')
       .addPermissionEnforcement(action, expectedLevel)
       .send();
   }),
@@ -210,7 +210,7 @@ webhooks.on(
       .addBlock(createMessageBlock(text))
       .addUser(event.payload.member, 'Collaborator')
       .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
-      .addSeverity('normal')
+      .addSeverity('critical')
       .addPermissionEnforcement(action, expectedLevel)
       .send();
   }),
@@ -239,7 +239,7 @@ webhooks.on(
       .addBlock(createMarkdownBlock(text))
       .addUser(event.payload.member, 'Collaborator')
       .addRepositoryAndBlame(event.payload.repository, event.payload.sender)
-      .addSeverity('normal')
+      .addSeverity('critical')
       .addPermissionEnforcement(action, expectedLevel)
       .send();
   }),

--- a/src/permissions/run.ts
+++ b/src/permissions/run.ts
@@ -199,6 +199,12 @@ const validateConfigFast = async (config: PermissionsConfig) => {
   }
 };
 
+export const getValidatedConfig = async () => {
+  const config = await loadCurrentConfig();
+  await validateConfigFast(config);
+  return config;
+};
+
 async function main() {
   const builder = MessageBuilder.create();
   const config = await loadCurrentConfig();


### PR DESCRIPTION
Tested scenarios:
* Adding a collaborator who shouldn't be present
* Adding a collaborator who should be present
* Changing a collaborator permission level
* Removing a collaborator who should be present
* Removing a collaborator who shouldn't be present

There is a worst case scenario where I've somehow built an infinite-loop state machine but I've tested all cases and it looks good to me 🤷 

Partially solves #28, just need to do the same thing for team membership changes