### PR TITLE
fix: improve pr logic with explicit pr variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ The following environment variables represent the configuration of the actual Sh
 | `PERMISSIONS_FILE_REPO` | | Override the default repo to look for `config.yaml` | `.permissions` |
 | `PERMISSIONS_FILE_PATH` | | Override the default filepath to look for the Sheriff config | `config.yaml` |
 | `PERMISSIONS_FILE_REF` | | Override the default repo branch to look for the Sheriff config | `main` |
+| `PR_FILE_ORG` | | The name of the GitHub org where the PR has the `.permissions` repository | |
+| `PR_FILE_REPO` | | the name of the PR repo containing `config.yaml` | `.permissions` |
+| `PR_FILE_REF` | | The repo branch to look for the Sheriff config for the PR | `main` |
 | `GITHUB_WEBHOOK_SECRET` | ✔️ | The secret for the org-wide webhook you configured earlier | |
 | `SLACK_TOKEN` | ✔️ | The token for your Slack App you created earlier | |
 | `SLACK_WEBHOOK_URL` | ✔️ | The webhook URL for your Slack App you created earlier | |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,10 @@ export const PERMISSIONS_FILE_REPO = process.env.PERMISSIONS_FILE_REPO || '.perm
 export const PERMISSIONS_FILE_PATH = process.env.PERMISSIONS_FILE_PATH || 'config.yaml';
 export const PERMISSIONS_FILE_REF = process.env.PERMISSIONS_FILE_REF || 'main';
 
+export const PR_FILE_ORG = process.env.PR_FILE_ORG!;
+export const PR_FILE_REPO = process.env.PR_FILE_REPO || '.permissions';
+export const PR_FILE_REF = process.env.PR_FILE_REF || 'main';
+
 export const SHERIFF_IMPORTANT_BRANCH = process.env.SHERIFF_IMPORTANT_BRANCH;
 
 export const AUTO_TUNNEL_NGROK = process.env.AUTO_TUNNEL_NGROK;

--- a/src/permissions/run.ts
+++ b/src/permissions/run.ts
@@ -15,6 +15,9 @@ import {
   PERMISSIONS_FILE_PATH,
   PERMISSIONS_FILE_REPO,
   PERMISSIONS_FILE_REF,
+  PR_FILE_ORG,
+  PR_FILE_REF,
+  PR_FILE_REPO,
 } from '../constants';
 import {
   PermissionsConfig,
@@ -42,10 +45,10 @@ const loadCurrentConfig = async () => {
 
   const octokit = await getOctokit();
   const contents = await octokit.repos.getContent({
-    owner: PERMISSIONS_FILE_ORG,
-    repo: PERMISSIONS_FILE_REPO,
+    owner: PR_FILE_ORG ? PR_FILE_ORG : PERMISSIONS_FILE_ORG,
+    repo: PR_FILE_REPO ? PR_FILE_REPO : PERMISSIONS_FILE_REPO,
     path: PERMISSIONS_FILE_PATH,
-    ref: PERMISSIONS_FILE_REF,
+    ref: PR_FILE_REF ? PR_FILE_REF : PERMISSIONS_FILE_REF,
   });
   if (Array.isArray(contents.data)) throw new Error('Invalid config file');
 


### PR DESCRIPTION
Turns out we actually need to track PR variables separately.

Example: We want to check what `jeefy/.permissions/config.yaml` would do against the `electron/.permissions` repo/org. 

Therefore we need both the PR org/repo/ref as well as the "primary" org/repo/ref. 

tl;dr: more env variables.

Signed-off-by: Jeffrey Sica <me@jeefy.dev>

edit: cc @MarshallOfSound ;) 