### PR TITLE
feat: allowlist certain releases via 'policy' system

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,4 +27,11 @@ export const SHERIFF_SLACK_DOMAIN = process.env.SHERIFF_SLACK_DOMAIN;
 export const SHERIFF_TRUSTED_RELEASERS = process.env.SHERIFF_TRUSTED_RELEASERS?.split(',').map(
   (s) => s.trim(),
 );
+// Used to allow automated releases that "follow" an upstream repo
+export const SHERIFF_TRUSTED_RELEASER_POLICIES: {
+  repository: string;
+  releaser: string;
+  mustMatchRepo: string;
+  actions: string[];
+}[] = JSON.parse(process.env.SHERIFF_TRUSTED_RELEASER_POLICIES || '[]');
 export const SHERIFF_SELF_LOGIN = process.env.SHERIFF_SELF_LOGIN || null;


### PR DESCRIPTION
It's a common pattern for certain automated repositories to "follow" releases of another repo, this allowlists and prevents notifications for releases that match an "upstream repo" policy.