### PR TITLE
feat: add support for assigning teams to heroku apps

### DIFF
--- a/src/permissions/run.ts
+++ b/src/permissions/run.ts
@@ -170,7 +170,7 @@ const validateConfigFast = async (config: PermissionsConfig): Promise<Organizati
             heroku: Joi.object({
               app_name: Joi.string().min(1).required(),
               team_name: Joi.string().min(1).required(),
-              access: Joi.array().items(Joi.string().min(1)).min(1).required(),
+              access: Joi.array().items(Joi.string().min(1)).optional(),
             }).optional(),
           })
           .required(),
@@ -261,6 +261,18 @@ const validateConfigFast = async (config: PermissionsConfig): Promise<Organizati
           throw new Error(
             `Team "${team}" assigned to "${repo.name}" does not exist in the "teams" config for "${orgConfig.organization}"`,
           );
+      }
+
+      if (repo.heroku && repo.heroku.access) {
+        for (const user of repo.heroku.access) {
+          if (user.startsWith('team:')) {
+            if (!orgConfig.teams.find((t) => t.name === user.slice('team:'.length))) {
+              throw new Error(
+                `Team "${user}" assigned to heroku for "${repo.name}" does not exist in the "teams" config for "${orgConfig.organization}"`,
+              );
+            }
+          }
+        }
       }
     }
   }

--- a/src/permissions/types.ts
+++ b/src/permissions/types.ts
@@ -16,7 +16,7 @@ export interface RepositoryConfig {
   heroku?: {
     app_name: string;
     team_name: string;
-    access: string[];
+    access?: string[];
   };
 }
 


### PR DESCRIPTION
Also supports assigning 0 people to an app, this will actually be the case for most apps as it's very rare folks actually need access to the underlying heroku app and not just the logs in datadog.