### PR TITLE
feat: add support for rulesets configured on repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ repositories:
       # Ruleset names must be unique for a given repository
       - name: <ruleset name>
         target: branch | tag
+        # Optional enforcement status, defaults to "active"
+        enforcement: disabled | active | evaluate
         # Optional bypass configuration
         bypass:
           # Team names that can bypass this ruleset
@@ -236,7 +238,7 @@ repositories:
             # in sheriff for good security practices
             app_id: <number>
 common_rulesets:
-  # Same structure as the object in `repositories[name].rulesets
+  # Same structure as the object in `repositories[name].rulesets`
   # Used to deduplicate rulesets that you want to apply to multiple repos
   - <object>
 ```

--- a/README.md
+++ b/README.md
@@ -184,6 +184,61 @@ repositories:
       has_wiki: <boolean>
     # Public vs Private repository, no value is assumed to mean public
     visibility: public | private
+    rulesets:
+      - name-of-common-ruleset
+      # Ruleset names must be unique for a given repository
+      - name: <ruleset name>
+        target: branch | tag
+        # Optional bypass configuration
+        bypass:
+          # Team names that can bypass this ruleset
+          teams: Array<string>
+          # App ids that can bypass this ruleset
+          apps: Array<number>
+        ref_name:
+          # Targeting ref for this ruleset, "~DEFAULT_BRANCH" is a magic
+          # string that GitHub translates to the current default branch
+          include: ["~DEFAULT_BRANCH"]
+          # Optional targeting ref for this ruleset that is _excluded_ from the
+          # include matching
+          exclude: []
+        # Which basic rules to apply as part of this ruleset
+        # Possible / supported options are included and documented below
+        rules:
+          # Prevent refs matching this ruleset from being created
+          - restrict_creation
+          # Prevent refs matching this ruleset from being updated
+          - restrict_update
+          # Prevent refs matching this ruleset from being deleted
+          - restrict_deletion
+          # Prevent refs matching this ruleset from receiving force pushes
+          - restrict_force_push
+          # Prevent refs matching this ruleset from receiving merge commits
+          - require_linear_history
+          # Require refs matching this ruleset only receive signed commits
+          - require_signed_commits
+        # Can be simply "true" to require pull requests before changes are pushed to
+        # matching refs. Advanced configuration can be provided via an object as documented
+        # below
+        require_pull_request:
+          # All params are optional and map exactly to the github API
+          # They are also all quite literal :)
+          dismiss_stale_reviews_on_push: <boolean>
+          require_code_owner_review: <boolean>
+          require_last_push_approval: <boolean>
+          required_approving_review_count: <number>
+          required_review_thread_resolution: <boolean>
+        # Status checks that are required to make changes to the matching ref
+        require_status_checks:
+            # The literal check name that is required, this is what shows up in the GitHub UI
+          - context: <string>
+            # The app ID that makes this check, this is optional in the GitHub API but required
+            # in sheriff for good security practices
+            app_id: <number>
+common_rulesets:
+  # Same structure as the object in `repositories[name].rulesets
+  # Used to deduplicate rulesets that you want to apply to multiple repos
+  - <object>
 ```
 
 #### Generating your initial configuration

--- a/package.json
+++ b/package.json
@@ -30,12 +30,14 @@
     "fs-extra": "^8.0.1",
     "googleapis": "^109.0.1",
     "heroku-client": "^3.1.0",
+    "jest-diff": "^29.7.0",
     "joi": "^17.13.3",
     "js-yaml": "^3.13.1",
     "ora": "^5.1.2",
     "queue": "^6.0.2"
   },
   "devDependencies": {
+    "@octokit/openapi-types": "^24.0.0",
     "@types/dotenv": "^8.2.0",
     "@types/dotenv-safe": "^8.1.6",
     "@types/express": "^4.17.0",

--- a/src/permissions/ruleset.ts
+++ b/src/permissions/ruleset.ts
@@ -1,0 +1,160 @@
+import type { components as OctokitTypes } from '@octokit/openapi-types';
+import { diff } from 'jest-diff';
+
+import { Ruleset } from './types.js';
+
+export function rulesetToGithub(ruleset: Ruleset, allTeams: { id: number; name: string }[]) {
+  const generatedRules: OctokitTypes['schemas']['repository-rule'][] = [];
+  if (ruleset.rules) {
+    for (const basicRule of ruleset.rules) {
+      switch (basicRule) {
+        case 'require_linear_history':
+          generatedRules.push({
+            type: 'required_linear_history',
+          });
+          break;
+        case 'require_signed_commits':
+          generatedRules.push({
+            type: 'required_signatures',
+          });
+          break;
+        case 'restrict_creation':
+          generatedRules.push({
+            type: 'creation',
+          });
+          break;
+        case 'restrict_deletion':
+          generatedRules.push({
+            type: 'deletion',
+          });
+          break;
+        case 'restrict_update':
+          generatedRules.push({
+            type: 'update',
+          });
+          break;
+        case 'restrict_force_push':
+          generatedRules.push({
+            type: 'non_fast_forward',
+          });
+          break;
+      }
+    }
+  }
+  if (ruleset.require_pull_request) {
+    generatedRules.push({
+      type: 'pull_request',
+      parameters:
+        ruleset.require_pull_request === true
+          ? undefined
+          : {
+              dismiss_stale_reviews_on_push:
+                ruleset.require_pull_request.dismiss_stale_reviews_on_push ?? false,
+              require_code_owner_review:
+                ruleset.require_pull_request.require_code_owner_review ?? false,
+              require_last_push_approval:
+                ruleset.require_pull_request.require_last_push_approval ?? false,
+              required_approving_review_count:
+                ruleset.require_pull_request.required_approving_review_count ?? 0,
+              required_review_thread_resolution:
+                ruleset.require_pull_request.required_review_thread_resolution ?? false,
+            },
+    });
+  }
+  if (ruleset.require_status_checks) {
+    generatedRules.push({
+      type: 'required_status_checks',
+      parameters: {
+        required_status_checks: ruleset.require_status_checks.map((check) => ({
+          context: check.context,
+          integration_id: check.app_id,
+        })),
+        strict_required_status_checks_policy: false,
+      },
+    });
+  }
+  return {
+    name: ruleset.name,
+    target: ruleset.target,
+    enforcement: ruleset.enforcement || 'active',
+    bypass_actors: ruleset.bypass
+      ? [
+          ...(ruleset.bypass?.apps?.map((appId) => ({
+            actor_id: appId,
+            actor_type: 'Integration' as const,
+            bypass_mode: 'always' as const,
+          })) || []),
+          ...(ruleset.bypass?.teams?.map((teamName) => ({
+            actor_id: allTeams.find((t) => t.name === teamName)!.id,
+            actor_type: 'Team' as const,
+            bypass_mode: 'always' as const,
+          })) || []),
+        ].sort(sortBypassActors)
+      : undefined,
+    conditions: {
+      ref_name: {
+        include: ruleset.ref_name.include,
+        exclude: ruleset.ref_name.exclude || [],
+      },
+    },
+    rules: generatedRules.sort((a, b) => a.type.localeCompare(b.type)),
+  } as const;
+}
+
+type BypassActor = Required<OctokitTypes['schemas']['repository-ruleset']>['bypass_actors'][0];
+function sortBypassActors(a: BypassActor, b: BypassActor): number {
+  if (a.actor_type === b.actor_type) {
+    return a.actor_id! - b.actor_id!;
+  }
+  return a.actor_type!.localeCompare(b.actor_type!);
+}
+
+export function getDifferenceWithGithubRuleset(
+  ruleset: ReturnType<typeof rulesetToGithub>,
+  githubRuleset: OctokitTypes['schemas']['repository-ruleset'] | null,
+  stripAnsi: boolean,
+) {
+  const _clonedGithubRuleset: OctokitTypes['schemas']['repository-ruleset'] = githubRuleset
+    ? JSON.parse(JSON.stringify(githubRuleset))
+    : githubRuleset;
+  const clonedGitHubRuleset: ReturnType<typeof rulesetToGithub> = githubRuleset
+    ? {
+        name: _clonedGithubRuleset.name,
+        target: _clonedGithubRuleset.target as any,
+        enforcement: _clonedGithubRuleset.enforcement,
+        bypass_actors: _clonedGithubRuleset.bypass_actors?.sort(sortBypassActors) as any,
+        conditions: _clonedGithubRuleset.conditions! as any,
+        rules: _clonedGithubRuleset.rules?.sort((a, b) => a.type.localeCompare(b.type)) as any,
+      }
+    : ({} as any);
+
+  if (stripAnsi) {
+    const difference = diff(ruleset, clonedGitHubRuleset, {
+      aColor: (a) => a,
+      bColor: (a) => a,
+      changeColor: (a) => a,
+      changeLineTrailingSpaceColor: (a) => a,
+      commonColor: (a) => a,
+      commonLineTrailingSpaceColor: (a) => a,
+      patchColor: (a) => a,
+      aAnnotation: 'New',
+      bAnnotation: 'Old',
+      aIndicator: '+',
+      bIndicator: '-',
+    });
+    if (difference?.trim() === 'Compared values have no visual difference.') {
+      return null;
+    }
+    return difference;
+  }
+  const difference = diff(ruleset, clonedGitHubRuleset, {
+    aAnnotation: 'New',
+    bAnnotation: 'Old',
+    aIndicator: '+',
+    bIndicator: '-',
+  });
+  if (difference?.trim() === 'Compared values have no visual difference.') {
+    return null;
+  }
+  return difference;
+}

--- a/src/permissions/run.ts
+++ b/src/permissions/run.ts
@@ -150,7 +150,8 @@ const validateConfigFast = async (config: PermissionsConfig): Promise<Organizati
           'restrict_force_push',
         ),
       )
-      .required(),
+      .min(1)
+      .optional(),
     require_pull_request: Joi.alternatives(
       Joi.boolean().valid(true),
       Joi.object({
@@ -1396,7 +1397,7 @@ async function checkRepository(
 
     const rulesetsToAdd: Ruleset[] = [];
 
-    // Figure out which rulesets we do not have at tall
+    // Figure out which rulesets we do not have at all
     for (const ruleset of expectedRulesets) {
       if (!currentRulesets.some((r) => r.name === ruleset.name)) {
         rulesetsToAdd.push(ruleset);

--- a/src/permissions/types.ts
+++ b/src/permissions/types.ts
@@ -1,5 +1,41 @@
 export type SheriffAccessLevel = 'read' | 'triage' | 'write' | 'maintain' | 'admin';
 export type GitHubAccessLevel = 'pull' | 'triage' | 'push' | 'maintain' | 'admin';
+
+export type BasicRule =
+  | 'restrict_creation'
+  | 'restrict_update'
+  | 'restrict_deletion'
+  | 'require_linear_history'
+  | 'require_signed_commits'
+  | 'restrict_force_push';
+
+export interface Ruleset {
+  name: string;
+  target: 'branch' | 'tag';
+  enforcement?: 'disabled' | 'active' | 'evaluate';
+  bypass?: {
+    teams?: string[];
+    apps?: number[];
+  };
+  ref_name: {
+    include: string[];
+    exclude?: string[];
+  };
+  rules?: BasicRule[];
+  require_pull_request?:
+    | true
+    | {
+        dismiss_stale_reviews_on_push?: boolean;
+        require_code_owner_review?: boolean;
+        require_last_push_approval?: boolean;
+        required_approving_review_count: number;
+        required_review_thread_resolution?: boolean;
+      };
+  require_status_checks?: {
+    context: string;
+    app_id: number;
+  }[];
+}
 export interface RepositoryConfig {
   name: string;
   /**
@@ -13,6 +49,7 @@ export interface RepositoryConfig {
   settings?: Partial<RepoSettings>;
   visibility?: 'public' | 'private' | 'current';
   properties?: Record<string, string>;
+  rulesets?: (Ruleset | string)[];
   heroku?: {
     app_name: string;
     team_name: string;
@@ -42,6 +79,7 @@ export interface OrganizationConfig {
   repository_defaults: RepoSettings;
   teams: TeamConfig[];
   repositories: RepositoryConfig[];
+  common_rulesets?: Ruleset[];
 }
 
 export type PermissionsConfig = OrganizationConfig | OrganizationConfig[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,13 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
 "@octokit/auth-app@^4.0.13":
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/@octokit/auth-app/-/auth-app-4.0.13.tgz#53323bee6bfefbb73ea544dd8e6a0144550e13e3"
@@ -97,16 +104,16 @@
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/core@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-5.0.1.tgz#865da2b30d54354cccb6e30861ddfa0e24494780"
-  integrity sha512-lyeeeZyESFo+ffI801SaBKmCfsvarO+dgV8/0gD8u1d87clbEdWsP5yC+dSj3zLhb2eIf5SJrn6vDz9AheETHw==
+"@octokit/core@^5.0.2":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-5.2.1.tgz#58c21a5f689ee81e0b883b5aa77573a7ff1b4ea1"
+  integrity sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==
   dependencies:
     "@octokit/auth-token" "^4.0.0"
-    "@octokit/graphql" "^7.0.0"
-    "@octokit/request" "^8.0.2"
-    "@octokit/request-error" "^5.0.0"
-    "@octokit/types" "^12.0.0"
+    "@octokit/graphql" "^7.1.0"
+    "@octokit/request" "^8.4.1"
+    "@octokit/request-error" "^5.1.1"
+    "@octokit/types" "^13.0.0"
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
@@ -119,13 +126,12 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/endpoint@^9.0.0":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-9.0.1.tgz#c3f69d27accddcb04a3199fcef541804288149d2"
-  integrity sha512-hRlOKAovtINHQPYHZlfyFwaM8OyetxeoC81lAkBy34uLb8exrZB50SQdeW3EROqiY9G9yxQTpp5OHTV54QD+vA==
+"@octokit/endpoint@^9.0.6":
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-9.0.6.tgz#114d912108fe692d8b139cfe7fc0846dfd11b6c0"
+  integrity sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==
   dependencies:
-    "@octokit/types" "^12.0.0"
-    is-plain-object "^5.0.0"
+    "@octokit/types" "^13.1.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/graphql@^5.0.0", "@octokit/graphql@^5.0.6":
@@ -137,13 +143,13 @@
     "@octokit/types" "^9.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/graphql@^7.0.0":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-7.0.2.tgz#3df14b9968192f9060d94ed9e3aa9780a76e7f99"
-  integrity sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==
+"@octokit/graphql@^7.1.0":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-7.1.1.tgz#79d9f3d0c96a8fd13d64186fe5c33606d48b79cc"
+  integrity sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==
   dependencies:
-    "@octokit/request" "^8.0.1"
-    "@octokit/types" "^12.0.0"
+    "@octokit/request" "^8.4.1"
+    "@octokit/types" "^13.0.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/oauth-authorization-url@^5.0.0":
@@ -162,25 +168,27 @@
     "@octokit/types" "^9.0.0"
     btoa-lite "^1.0.0"
 
-"@octokit/openapi-types@^17.2.0":
-  version "17.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-17.2.0.tgz#f1800b5f9652b8e1b85cc6dfb1e0dc888810bdb5"
-  integrity sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ==
+"@octokit/openapi-types@^18.0.0":
+  version "18.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-18.1.1.tgz#09bdfdabfd8e16d16324326da5148010d765f009"
+  integrity sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==
 
-"@octokit/openapi-types@^19.0.1":
-  version "19.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-19.0.1.tgz#b83bd8ef1a6e1a2d88072c87747fa130348ef8fe"
-  integrity sha512-zC+73r2HIoRb9rWW5S3Y759hrpadlD5pNnya/QfZv0JZE7mvMu+FUa7nxHqTadi2hZc4BPZjJ8veDTuJnh8+8g==
-
-"@octokit/openapi-types@^22.2.0":
-  version "22.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-22.2.0.tgz#75aa7dcd440821d99def6a60b5f014207ae4968e"
-  integrity sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==
+"@octokit/openapi-types@^24.0.0", "@octokit/openapi-types@^24.2.0":
+  version "24.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-24.2.0.tgz#3d55c32eac0d38da1a7083a9c3b0cca77924f7d3"
+  integrity sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==
 
 "@octokit/openapi-webhooks-types@8.3.0":
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-8.3.0.tgz#a7a4da00c0f27f7f5708eb3fcebefa08f8d51125"
   integrity sha512-vKLsoR4xQxg4Z+6rU/F65ItTUz/EXbD+j/d4mlq2GW8TsA4Tc8Kdma2JTAAJ5hrKWUQzkR/Esn2fjsqiVRYaQg==
+
+"@octokit/plugin-paginate-rest@11.4.4-cjs.2":
+  version "11.4.4-cjs.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz#979a10d577bce7a393e8e65953887e42b0a05000"
+  integrity sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==
+  dependencies:
+    "@octokit/types" "^13.7.0"
 
 "@octokit/plugin-paginate-rest@^6.1.2":
   version "6.1.2"
@@ -189,13 +197,6 @@
   dependencies:
     "@octokit/tsconfig" "^1.0.2"
     "@octokit/types" "^9.2.3"
-
-"@octokit/plugin-paginate-rest@^9.0.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.0.tgz#215040a2e9d93497b46d7f88c8566f958c97e1c4"
-  integrity sha512-FK1WMa5261SaMX/33S1EOEzalnu9+YoKfrxzRVimciachMFSWH9kQ9SOKdxxxuZXX+KxCLw1knQkneSLYmgdbg==
-  dependencies:
-    "@octokit/types" "^12.1.0"
 
 "@octokit/plugin-request-log@^1.0.4":
   version "1.0.4"
@@ -207,12 +208,12 @@
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz#260fa6970aa97bbcbd91f99f3cd812e2b285c9f1"
   integrity sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==
 
-"@octokit/plugin-rest-endpoint-methods@^10.0.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.1.0.tgz#0633ba7da42b9333444dd0880ab383a0860662fb"
-  integrity sha512-SnVot2WFI61LYkTeSCkKNfvfqw7FdgtqvaC8nMUwYiHA8UTKoGDjL+R5pCaCEvoLu3O55pUOtNaTIyo7ngJySQ==
+"@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1":
+  version "13.3.2-cjs.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz#d0a142ff41d8f7892b6ccef45979049f51ecaa8d"
+  integrity sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==
   dependencies:
-    "@octokit/types" "^12.1.0"
+    "@octokit/types" "^13.8.0"
 
 "@octokit/plugin-rest-endpoint-methods@^7.1.2":
   version "7.1.2"
@@ -231,12 +232,12 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request-error@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-5.0.1.tgz#277e3ce3b540b41525e07ba24c5ef5e868a72db9"
-  integrity sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==
+"@octokit/request-error@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-5.1.1.tgz#b9218f9c1166e68bb4d0c89b638edc62c9334805"
+  integrity sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==
   dependencies:
-    "@octokit/types" "^12.0.0"
+    "@octokit/types" "^13.1.0"
     deprecation "^2.0.0"
     once "^1.4.0"
 
@@ -259,21 +260,20 @@
     node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
-"@octokit/request@^8.0.1", "@octokit/request@^8.0.2":
-  version "8.1.4"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-8.1.4.tgz#12dfaebdb2ea375eaabb41d39d45182531ac2857"
-  integrity sha512-M0aaFfpGPEKrg7XoA/gwgRvc9MSXHRO2Ioki1qrPDbl1e9YhjIwVoHE7HIKmv/m3idzldj//xBujcFNqGX6ENA==
+"@octokit/request@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-8.4.1.tgz#715a015ccf993087977ea4365c44791fc4572486"
+  integrity sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==
   dependencies:
-    "@octokit/endpoint" "^9.0.0"
-    "@octokit/request-error" "^5.0.0"
-    "@octokit/types" "^12.0.0"
-    is-plain-object "^5.0.0"
+    "@octokit/endpoint" "^9.0.6"
+    "@octokit/request-error" "^5.1.1"
+    "@octokit/types" "^13.1.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^19.0.11":
-  version "19.0.11"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-19.0.11.tgz#2ae01634fed4bd1fca5b642767205ed3fd36177c"
-  integrity sha512-m2a9VhaP5/tUw8FwfnW2ICXlXpLPIqxtg3XcAiGMLj/Xhw3RSBfZ8le/466ktO1Gcjr8oXudGnHhxV1TXJgFxw==
+  version "19.0.13"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-19.0.13.tgz#e799393264edc6d3c67eeda9e5bd7832dcf974e4"
+  integrity sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==
   dependencies:
     "@octokit/core" "^4.2.1"
     "@octokit/plugin-paginate-rest" "^6.1.2"
@@ -281,40 +281,33 @@
     "@octokit/plugin-rest-endpoint-methods" "^7.1.2"
 
 "@octokit/rest@^20.0.2":
-  version "20.0.2"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-20.0.2.tgz#5cc8871ba01b14604439049e5f06c74b45c99594"
-  integrity sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==
+  version "20.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-20.1.2.tgz#1d74d0c72ade0d64f7c5416448d5c885f5e3ccc4"
+  integrity sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==
   dependencies:
-    "@octokit/core" "^5.0.0"
-    "@octokit/plugin-paginate-rest" "^9.0.0"
+    "@octokit/core" "^5.0.2"
+    "@octokit/plugin-paginate-rest" "11.4.4-cjs.2"
     "@octokit/plugin-request-log" "^4.0.0"
-    "@octokit/plugin-rest-endpoint-methods" "^10.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "13.3.2-cjs.1"
 
 "@octokit/tsconfig@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@octokit/tsconfig/-/tsconfig-1.0.2.tgz#59b024d6f3c0ed82f00d08ead5b3750469125af7"
   integrity sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==
 
-"@octokit/types@^12.0.0", "@octokit/types@^12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-12.1.0.tgz#e31f6d524efb9d49206c5b28ab18fd6688f6a12a"
-  integrity sha512-JmjQr5ZbOnpnOLX5drI2O2I1N9suOYZAgINHXTlVVg4lRtUifMv2JssT+RhmNxQwXH153Pc8HaCMdTRkqI1oVQ==
+"@octokit/types@^13.0.0", "@octokit/types@^13.1.0", "@octokit/types@^13.7.0", "@octokit/types@^13.8.0":
+  version "13.10.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-13.10.0.tgz#3e7c6b19c0236c270656e4ea666148c2b51fd1a3"
+  integrity sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==
   dependencies:
-    "@octokit/openapi-types" "^19.0.1"
-
-"@octokit/types@^13.0.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-13.5.0.tgz#4796e56b7b267ebc7c921dcec262b3d5bfb18883"
-  integrity sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==
-  dependencies:
-    "@octokit/openapi-types" "^22.2.0"
+    "@octokit/openapi-types" "^24.2.0"
 
 "@octokit/types@^9.0.0", "@octokit/types@^9.2.3":
-  version "9.2.3"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-9.2.3.tgz#d0af522f394d74b585cefb7efd6197ca44d183a9"
-  integrity sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-9.3.2.tgz#3f5f89903b69f6a2d196d78ec35f888c0013cac5"
+  integrity sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==
   dependencies:
-    "@octokit/openapi-types" "^17.2.0"
+    "@octokit/openapi-types" "^18.0.0"
 
 "@octokit/webhooks-methods@^5.0.0":
   version "5.1.0"
@@ -346,6 +339,11 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
+
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
@@ -634,6 +632,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-styles@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.1.0.tgz#87313c102b8118abd57371afab34618bf7350ed3"
@@ -816,7 +819,7 @@ call-bind@^1.0.7:
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.1"
 
-chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1019,6 +1022,11 @@ destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 dotenv-safe@^6.1.0:
   version "6.1.0"
@@ -1596,6 +1604,21 @@ itermcolors-to-hex@^1.0.1:
     plist "^3.0.1"
     rgb-hex "^2.1.0"
 
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
+
 joi@^17.13.3:
   version "17.13.3"
   resolved "https://registry.yarnpkg.com/joi/-/joi-17.13.3.tgz#0f5cc1169c999b30d344366d384b12d92558bcec"
@@ -2072,6 +2095,15 @@ prettier@^2.7.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -2133,6 +2165,11 @@ raw-body@2.5.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 readable-stream@^3.4.0:
   version "3.6.0"


### PR DESCRIPTION
This let's sheriff manage (create, update, delete) rulesets for our repos.

* If no rulesets are defined, manually defined rulesets in the UI are left alone
* If any ruleset is defined, all rulesets must be in the config file otherwise sheriff will delete unknown ones
* The exposed config API is specifically a subset and simpler version of the GitHub ruleset API
* dry runs show diff if an "update" operation would run
* `common_rulesets` allow us to declare "org" rulesets that we can then apply to multiple repos, for example "require signed commits"

This PR will allow us to progressively roll this out by configuring things on a per-repo basis. As part of the electron rollout of this we will have to convert existing legacy branch protection settings into rulesets.