### PR TITLE
fix: paginate installed repos in trusted-publisher plugin

### DIFF
--- a/src/permissions/plugins/trusted-publisher/index.ts
+++ b/src/permissions/plugins/trusted-publisher/index.ts
@@ -70,7 +70,7 @@ class TrustedPublisherPlugin implements Plugin {
 
     let installedRepos = this.installedRepos[org];
     if (!installedRepos && installId !== -1) {
-      const repos = await octokit.request(
+      const repos = await octokit.paginate<{ name: string }>(
         'GET /enterprises/{enterprise}/apps/organizations/{org}/installations/{installation_id}/repositories',
         {
           enterprise: enterprise,
@@ -79,7 +79,7 @@ class TrustedPublisherPlugin implements Plugin {
         },
       );
 
-      installedRepos = repos.data.map((r: { name: string }) => r.name);
+      installedRepos = repos.map((r) => r.name);
       this.installedRepos[org] = installedRepos;
     }
 


### PR DESCRIPTION
## Summary

The trusted-publisher plugin caches the list of repositories installed under the npm publisher GitHub App per-org. The fetch at `src/permissions/plugins/trusted-publisher/index.ts:73` was using a non-paginated `octokit.request`, so only the first ~30 results were cached. Any repo beyond that page (e.g. `extract-zip`, recently added in electron/.permissions#347) was repeatedly treated as not-installed, causing the cron to re-issue the idempotent `add` PATCH and log `Installing npm publisher github app into <repo>` on every run, plus add a noisy line to the Slack summary.

Switching to `octokit.paginate` matches the pattern already used immediately above for the installations lookup, and lets octokit unwrap the `{ total_count, repositories }` envelope into a flat array — so we can also drop the `.data` indirection.

_Note: We should run a dry run after this is merged to make sure it's catching the new apps._

🤖 Generated with [Claude Code](https://claude.com/claude-code)