### PR TITLE
fix: skip deleted repo alerts for GHSA security advisory repos

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,6 +5,13 @@ export const isMainRepo = (repo: webhookComponents['schemas']['repository-webhoo
   return repo.name === repo.owner.login;
 };
 
+const SECURITY_ADVISORY_REPO_PATTERN =
+  /^[\w]+-ghsa-[A-Za-z0-9-]{4}-[A-Za-z0-9-]{4}-[A-Za-z0-9-]{4}$/;
+
+export const isSecurityAdvisoryRepo = (repo: { name: string }) => {
+  return SECURITY_ADVISORY_REPO_PATTERN.test(repo.name);
+};
+
 type HookContext = {
   log: (...args: any[]) => void;
   error: (...args: any[]) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   createNodeMiddleware,
   EmitterWebhookEvent,
 } from '@octokit/webhooks';
-import { isMainRepo, hook } from './helpers.js';
+import { isMainRepo, isSecurityAdvisoryRepo, hook } from './helpers.js';
 import {
   MessageBuilder,
   createMessageBlock,
@@ -352,6 +352,7 @@ webhooks.on(
   'repository.deleted',
   hook(async (event) => {
     if (event.payload.sender.login === SHERIFF_SELF_LOGIN) return;
+    if (isSecurityAdvisoryRepo(event.payload.repository)) return;
 
     const text = 'A repository was just deleted';
     await MessageBuilder.create()


### PR DESCRIPTION
## Summary

- Skip "deleted repo" alerts for GHSA (GitHub Security Advisory) repos
- These repos follow the pattern `*-ghsa-XXXX-XXXX-XXXX` and are temporary repos created for security advisories
- Their deletion is expected behavior and shouldn't trigger critical alerts

## Test plan

- [ ] Verify the regex pattern matches GHSA repo names like `electron-ghsa-1234-5678-9abc`
- [ ] Confirm regular repo deletions still trigger alerts
- [ ] Check that the pattern is consistent with the existing filter in `permissions/run.ts`

Slack thread: https://electronhq.slack.com/archives/GKN8ZB7QX/p1780853972905379

https://claude.ai/code/session_01Fm6UoHK3YHio9Twuv5eBsb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm6UoHK3YHio9Twuv5eBsb)_